### PR TITLE
Fix bug in Gst.Pad.set_query_function

### DIFF
--- a/gi/overrides/Gst.py
+++ b/gi/overrides/Gst.py
@@ -146,11 +146,11 @@ class Pad(Gst.Pad):
 
     def set_query_function(self, func):
         self._real_query_func = func
-        self.set_query_function_full(self._chain_override, None)
+        self._real_set_query_function_full(self._query_override, None)
 
     def set_query_function_full(self, func, udata):
         self._real_query_func = func
-        self._real_set_query_function_full(self._query_override, None)
+        self._real_set_query_function_full(self._query_override, udata)
 
     def query_caps(self, filter=None):
         return Gst.Pad.query_caps(self, filter)


### PR DESCRIPTION
Previously this was setting the chain function instead of the query function when you attempted to override the query operation. This also passes udata into the _real_set_query_function_full in the _full version of the wrapper, as that seems correct, but there may have been some rationale behind that omission.